### PR TITLE
Update mrg32k3a.jl

### DIFF
--- a/src/mrg32k3a.jl
+++ b/src/mrg32k3a.jl
@@ -188,7 +188,7 @@ end
 """
 Computes (a*s + c) % m, all must be < 2^35. Overflow-safe.
 """
-function MultModM (a::Int64, s::Int64, c::Int64, m::Int64)
+function MultModM(a::Int64, s::Int64, c::Int64, m::Int64)
     val = a * Float64(s) + c
     if abs(val) < two53
         v = Int64(val)


### PR DESCRIPTION
Correct a compilation error with Julia 0.5.0: the space between the function name "MultModM" and the opening bracket for the   arguments should be removed.
